### PR TITLE
Fix possible null ptr dereferencing

### DIFF
--- a/cmdtreemodel.cpp
+++ b/cmdtreemodel.cpp
@@ -163,8 +163,11 @@ void CMDTreeModel::setupModelData()
 
                 pGroup = new CTreeItem(ItemRole::GROUP, trackGroup, pDisc);
             }
-            pTrack = new CTreeItem(ItemRole::TRACK, track, pGroup);
-            pGroup->appendChild(pTrack);
+            if (pGroup != nullptr)
+            {
+                pTrack = new CTreeItem(ItemRole::TRACK, track, pGroup);
+                pGroup->appendChild(pTrack);
+            }
         }
     }
 


### PR DESCRIPTION
Clang-tidy caught the following issue:
```
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:167:13: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
            pGroup->appendChild(pTrack);
            ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:31:5: note: Calling 'CMDTreeModel::setupModelData'
    setupModelData();
    ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:126:5: note: 'pGroup' initialized to a null pointer value
    CTreeItem*  pGroup = nullptr;
    ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:136:13: note: Assuming the condition is false
        if (trackGroup.empty())
            ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:136:9: note: Taking false branch
        if (trackGroup.empty())
        ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:152:13: note: Taking false branch
            if (trackGroup != currGrp)
            ^
/home/runner/work/cd2netmd_gui/cd2netmd_gui/cmdtreemodel.cpp:167:13: note: Called C++ object pointer is null
            pGroup->appendChild(pTrack);
            ^
```

This is a a simple and stupid fix to not get Undefined Behavior by calling dereferencing a null pointer.